### PR TITLE
setting mflike highest version to be 0.9.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.9.0"
-dependencies = ["mflike >=0.9.4, <= 0.9.7"]
+dependencies = ["mflike >=0.9.4, < 1"]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "camb"]


### PR DESCRIPTION
This is a (temporary?) solution for keeping working with the last version of MFLike (<= 0.9.7, i.e. the PyPi release before the new version). 